### PR TITLE
Add stage arn output

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Available targets:
 | <a name="output_execution_arn"></a> [execution\_arn](#output\_execution\_arn) | The execution ARN part to be used in lambda\_permission's source\_arn when allowing API Gateway to invoke a Lambda <br>    function, e.g., arn:aws:execute-api:eu-west-2:123456789012:z4675bid1j, which can be concatenated with allowed stage, <br>    method and resource path.The ARN of the Lambda function that will be executed. |
 | <a name="output_id"></a> [id](#output\_id) | The ID of the REST API |
 | <a name="output_invoke_url"></a> [invoke\_url](#output\_invoke\_url) | The URL to invoke the REST API |
+| <a name="output_stage_arn"></a> [stage\_arn](#output\_stage\_arn) | The ARN of the gateway stage |
 | <a name="output_root_resource_id"></a> [root\_resource\_id](#output\_root\_resource\_id) | The resource ID of the REST API's root |
 <!-- markdownlint-restore -->
 

--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ Available targets:
 | <a name="output_execution_arn"></a> [execution\_arn](#output\_execution\_arn) | The execution ARN part to be used in lambda\_permission's source\_arn when allowing API Gateway to invoke a Lambda <br>    function, e.g., arn:aws:execute-api:eu-west-2:123456789012:z4675bid1j, which can be concatenated with allowed stage, <br>    method and resource path.The ARN of the Lambda function that will be executed. |
 | <a name="output_id"></a> [id](#output\_id) | The ID of the REST API |
 | <a name="output_invoke_url"></a> [invoke\_url](#output\_invoke\_url) | The URL to invoke the REST API |
-| <a name="output_stage_arn"></a> [stage\_arn](#output\_stage\_arn) | The ARN of the gateway stage |
 | <a name="output_root_resource_id"></a> [root\_resource\_id](#output\_root\_resource\_id) | The resource ID of the REST API's root |
+| <a name="output_stage_arn"></a> [stage\_arn](#output\_stage\_arn) | The ARN of the gateway stage |
 <!-- markdownlint-restore -->
 
 
@@ -311,7 +311,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -69,4 +69,5 @@
 | <a name="output_id"></a> [id](#output\_id) | The ID of the REST API |
 | <a name="output_invoke_url"></a> [invoke\_url](#output\_invoke\_url) | The URL to invoke the REST API |
 | <a name="output_root_resource_id"></a> [root\_resource\_id](#output\_root\_resource\_id) | The resource ID of the REST API's root |
+| <a name="output_stage_arn"></a> [stage\_arn](#output\_stage\_arn) | The ARN of the gateway stage |
 <!-- markdownlint-restore -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,3 +31,8 @@ output "invoke_url" {
   description = "The URL to invoke the REST API"
   value       = module.this.enabled ? aws_api_gateway_stage.this[0].invoke_url : null
 }
+
+output "stage_arn" {
+  description = "The ARN of the gateway stage"
+  value       = module.this.enabled ? aws_api_gateway_stage.this[0].arn : null
+}


### PR DESCRIPTION
## what

* Added gateway's stage arn to output. 
* Updated readme to include the new output. 

## why

* The stage arn is needed when defining associations between API gateway stage and a WAF, specifically in the [WAF's association resource arns  list](https://github.com/cloudposse/terraform-aws-waf#inputs) in cloudposse/terraform-aws-waf module.


