### PR TITLE
Fix typo in example

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The table below correctly indicates which inputs are required.
 Setup the account-level settings for logging and metrics for API Gateway:
 
 ```hcl
-module "api_gateway_account_settgings" {
+module "api_gateway_account_settings" {
   source  = "cloudposse/api-gateway/aws//modules/account-settings"
   # version = "x.x.x"
 
@@ -383,7 +383,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-api-gateway&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-api-gateway&utm_content=website
@@ -414,3 +414,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-api-gateway
   [share_email]: mailto:?subject=terraform-aws-api-gateway&body=https://github.com/cloudposse/terraform-aws-api-gateway
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-api-gateway?pixel&cs=github&cm=readme&an=terraform-aws-api-gateway
+<!-- markdownlint-restore -->

--- a/README.md
+++ b/README.md
@@ -99,10 +99,6 @@ We highly recommend that in your code you pin the version to the exact version y
 using so that your infrastructure remains stable, and update versions in a
 systematic way so that they do not catch you by surprise.
 
-Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
-the registry shows many of our inputs as required when in fact they are optional.
-The table below correctly indicates which inputs are required.
-
 
 
 Setup the account-level settings for logging and metrics for API Gateway:
@@ -316,7 +312,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2023 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -94,7 +94,7 @@ usage: |-
   Setup the account-level settings for logging and metrics for API Gateway:
 
   ```hcl
-  module "api_gateway_account_settgings" {
+  module "api_gateway_account_settings" {
     source  = "cloudposse/api-gateway/aws//modules/account-settings"
     # version = "x.x.x"
 


### PR DESCRIPTION
## what
* Fixes typo in example module syntax

## why
* Consistent spelling is good

## references
* n/a

