### PR TITLE
Fix error when create private API Gateway with resource policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ resource "aws_api_gateway_deployment" "this" {
   lifecycle {
     create_before_destroy = true
   }
-  depends_on = [ aws_api_gateway_rest_api_policy.this ]
+  depends_on = [aws_api_gateway_rest_api_policy.this]
 }
 
 resource "aws_api_gateway_stage" "this" {

--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,7 @@ resource "aws_api_gateway_deployment" "this" {
   lifecycle {
     create_before_destroy = true
   }
+  depends_on = [ aws_api_gateway_rest_api_policy.this ]
 }
 
 resource "aws_api_gateway_stage" "this" {


### PR DESCRIPTION
## what

- add relations between `aws_api_gateway_deployment` and `aws_api_gateway_rest_api_policy`

## why

```
╷
│ Error: creating API Gateway Deployment: BadRequestException: Private REST API doesn't have a resource policy attached to it
│ 
│   with module.api_gwt.aws_api_gateway_deployment.this[0],
│   on ../../modules/api-gwt/main.tf line 39, in resource "aws_api_gateway_deployment" "this":
│   39: resource "aws_api_gateway_deployment" "this" {
│ 
╵
```

## references

- https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-resource-policies-create-attach.html
