### PR TITLE
feat: extend retention period for API Gateway logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Available targets:
 | <a name="input_private_link_target_arns"></a> [private\_link\_target\_arns](#input\_private\_link\_target\_arns) | A list of target ARNs for VPC Private Link | `list(string)` | `[]` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_rest_api_policy"></a> [rest\_api\_policy](#input\_rest\_api\_policy) | The IAM policy document for the API. | `string` | `null` | no |
+| <a name="input_retention_in_days"></a> [retention\_in\_days](#input\_retention\_in\_days) | Number of days you want to retain log events in the API Gateway log group | `string` | `"30"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_stage_name"></a> [stage\_name](#input\_stage\_name) | The name of the stage | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -59,6 +59,7 @@
 | <a name="input_private_link_target_arns"></a> [private\_link\_target\_arns](#input\_private\_link\_target\_arns) | A list of target ARNs for VPC Private Link | `list(string)` | `[]` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_rest_api_policy"></a> [rest\_api\_policy](#input\_rest\_api\_policy) | The IAM policy document for the API. | `string` | `null` | no |
+| <a name="input_retention_in_days"></a> [retention\_in\_days](#input\_retention\_in\_days) | Number of days you want to retain log events in the API Gateway log group | `string` | `"30"` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_stage_name"></a> [stage\_name](#input\_stage\_name) | The name of the stage | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ module "cloudwatch_log_group" {
   enabled              = local.create_log_group
   iam_tags_enabled     = var.iam_tags_enabled
   permissions_boundary = var.permissions_boundary
+  retention_in_days    = var.retention_in_days
 
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -141,6 +141,7 @@ variable "stage_name" {
 }
 
 variable "retention_in_days" {
+  type        = string
   description = "Number of days you want to retain log events in the API Gateway log group"
   default     = "30"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -139,3 +139,8 @@ variable "stage_name" {
   default     = ""
   description = "The name of the stage"
 }
+
+variable "retention_in_days" {
+  description = "Number of days you want to retain log events in the API Gateway log group"
+  default     = "30"
+}


### PR DESCRIPTION
## what

This feature allows users to customize the retention period of the logs in CloudWatch. 

## why
This is useful for users who need to keep logs for longer periods of time for auditing or compliance purposes.

## references
https://github.com/cloudposse/terraform-aws-api-gateway/issues/48