### PR TITLE
Add output for the Cloudwatch log group name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ locals {
   create_rest_api_policy = local.enabled && var.rest_api_policy != null
   create_log_group       = local.enabled && var.logging_level != "OFF"
   log_group_arn          = local.create_log_group ? module.cloudwatch_log_group.log_group_arn : null
+  log_group_name         = local.create_log_group ? module.cloudwatch_log_group.log_group_name : null
   vpc_link_enabled       = local.enabled && length(var.private_link_target_arns) > 0
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,3 +36,8 @@ output "stage_arn" {
   description = "The ARN of the gateway stage"
   value       = module.this.enabled ? aws_api_gateway_stage.this[0].arn : null
 }
+
+output "log_group_name" {
+  description = "The ARN of the Cloudwatch log group"
+  value       = local.log_group_name
+}


### PR DESCRIPTION
## what

<!--
- This feature provides an output of the cloudwatch log group name.
-->

## why

<!--
- The log group name is needed for log ingestion into log aggregation tools.
-->

## references

<!--
-->
