### PR TITLE
feat: customization of cloudwatch logs retention; update cloudwatch m…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,11 +28,13 @@ resource "aws_api_gateway_rest_api_policy" "this" {
 
 module "cloudwatch_log_group" {
   source  = "cloudposse/cloudwatch-logs/aws"
-  version = "0.6.8"
+  version = "0.6.9"
 
   enabled              = local.create_log_group
   iam_tags_enabled     = var.iam_tags_enabled
   permissions_boundary = var.permissions_boundary
+
+  retention_in_days = var.retention_in_days
 
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,12 @@ variable "logging_level" {
   }
 }
 
+variable "retention_in_days" {
+  type        = string
+  default     = "30"
+  description = "The number of days to retain logs for the API"
+}
+
 variable "metrics_enabled" {
   description = "A flag to indicate whether to enable metrics collection."
   type        = bool


### PR DESCRIPTION
## what
- Add customization of CloudWatch Logs retention (in days)
- Update CloudWatch module version to 0.6.9

## why
- Add the ability to change the default 30 days retention to the one you need

## references
- `closes [#48](https://github.com/cloudposse/terraform-aws-api-gateway/issues/48)`
