### PR TITLE
Feat/make private api work

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,11 +28,13 @@ resource "aws_api_gateway_rest_api_policy" "this" {
 
 module "cloudwatch_log_group" {
   source  = "cloudposse/cloudwatch-logs/aws"
-  version = "0.6.8"
+  version = "0.6.9"
 
   enabled              = local.create_log_group
   iam_tags_enabled     = var.iam_tags_enabled
   permissions_boundary = var.permissions_boundary
+
+  retention_in_days = var.retention_in_days
 
   context = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ resource "aws_api_gateway_rest_api" "this" {
 
   endpoint_configuration {
     types            = [var.endpoint_type]
+    ip_address_type  = var.ip_address_type
     vpc_endpoint_ids = var.vpc_endpoints
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,17 @@ variable "endpoint_type" {
   }
 }
 
+variable "ip_address_type" {
+  type        = string
+  description = "The type of IP address to use for the API. One of - IPV4, IPV6, DUALSTACK"
+  default     = "dualstack"
+
+  validation {
+    condition     = contains(["ipv4", "ipv6", "dualstack"], var.ip_address_type)
+    error_message = "Valid values for var: ip_address_type are (ipv4, ipv6, dualstack)."
+  }
+}
+
 variable "vpc_endpoints" {
   type        = list(string)
   description = "List of VPC Endpoint IDs to attach to the API Gateway"

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,12 @@ variable "logging_level" {
   }
 }
 
+variable "retention_in_days" {
+  type        = string
+  default     = "30"
+  description = "The number of days to retain logs for the API"
+}
+
 variable "metrics_enabled" {
   description = "A flag to indicate whether to enable metrics collection."
   type        = bool


### PR DESCRIPTION
## what
Introduced a new Terraform variable `ip_address_type` to allow explicit configuration of the network addressing scheme for the API infrastructure.

Configured the variable by default to `dualstack`, enabling native support for both IPv4 and IPv6 traffic routing.

Implemented built-in Terraform validation to enforce strict compliance with valid AWS networking configurations (ipv4, ipv6, or dualstack), catching invalid inputs early during the plan phase.

## why

Making the private API functional requires alignment with internal VPC routing architectures, especially when dealing with modern dual-stack environments or legacy IPv4-only networks.

Hardcoding the IP address type limits module reusability across different environments; exposing this parameter allows downstream deployments to adapt the API endpoints to local subnet restrictions.

Utilizing dualstack as the default ensures future-proof compatibility and seamless internal communication without breaking existing IPv4 workflows.

## references
